### PR TITLE
feat: add update_paint_style and update_text_style tools

### DIFF
--- a/src/tools/styles.ts
+++ b/src/tools/styles.ts
@@ -359,7 +359,7 @@ async function updatePaintStyleSingle(p: any) {
     const { r, g, b, a = 1 } = p.color;
     style.paints = [{ type: "SOLID", color: { r, g, b }, opacity: a }];
   }
-  return { id: style.id };
+  return "ok";
 }
 
 async function updateTextStyleSingle(p: any) {
@@ -388,7 +388,6 @@ async function updateTextStyleSingle(p: any) {
   if (p.textDecoration !== undefined) style.textDecoration = p.textDecoration;
 
   // WCAG recommendations
-  const result: any = { id: style.id };
   const hints: string[] = [];
   const effectiveFontSize = p.fontSize ?? style.fontSize;
   if (effectiveFontSize < 12) {
@@ -404,8 +403,8 @@ async function updateTextStyleSingle(p: any) {
       hints.push(`WCAG: Line height ${Math.ceil(effectiveFontSize * 1.5)}px (1.5×) recommended.`);
     }
   }
-  if (hints.length > 0) result.warning = hints.join(" ");
-  return result;
+  if (hints.length > 0) return { warning: hints.join(" ") };
+  return "ok";
 }
 
 export const figmaHandlers: Record<string, (params: any) => Promise<any>> = {


### PR DESCRIPTION
## Summary
- Adds `update_paint_style` tool to modify existing paint style color/name by ID or name
- Adds `update_text_style` tool to modify existing text style properties (font, size, line height, etc.) by ID or name
- Changes propagate to all nodes using the style — critical for WCAG remediation workflows
- Both support batch operations and name-based fuzzy lookup

Closes UFI-17

## Test plan

- [ ] **update_paint_style — change color by name**: pass style name + new color, verify nodes using it update
- [ ] **update_paint_style — rename style**: pass style ID + new name
- [ ] **update_paint_style — batch**: update 2+ styles in one call
- [ ] **update_paint_style — not found**: pass nonexistent name, expect error
- [ ] **update_text_style — change fontSize**: update to new size, verify propagation
- [ ] **update_text_style — WCAG fontSize warning**: set fontSize to 10, expect WCAG hint
- [ ] **update_text_style — WCAG lineHeight warning**: set tight lineHeight, expect WCAG hint
- [ ] **update_text_style — change fontFamily**: switch font family, verify font loads
- [ ] **update_text_style — change letterSpacing/textCase/textDecoration**: verify each field
- [ ] **update_text_style — name-based lookup**: pass style name instead of ID
- [ ] **update_text_style — not found**: pass nonexistent name, expect error
- [ ] **update_text_style — batch**: update 2+ styles in one call

🤖 Generated with [Claude Code](https://claude.com/claude-code)