### PR TITLE
refactor: unify tool response formats to use shared batchHandler

### DIFF
--- a/src/tools/create-text.ts
+++ b/src/tools/create-text.ts
@@ -51,23 +51,27 @@ function getFontStyle(weight: number): string {
   return map[weight] || "Regular";
 }
 
-/**
- * Batch create_text with font preloading.
- * Collects all unique fonts + text styles upfront, loads them in one Promise.all,
- * then creates nodes without per-item font loading overhead.
- */
-async function createTextBatch(params: any): Promise<{ results: any[] }> {
-  const items = params.items || [params];
-  const depth = params.depth;
+interface CreateTextContext {
+  textStyles: any[] | null;
+  paintStyles: any[] | null;
+  resolvedTextStyleMap: Map<string, any>;
+  setCharacters: (node: TextNode, text: string) => Promise<void>;
+}
 
-  // 1. Collect unique font keys needed (family::style format)
+/**
+ * Batch-level prep: collect fonts, resolve styles, preload everything once.
+ */
+async function prepCreateText(params: any): Promise<CreateTextContext> {
+  const items = params.items || [params];
+
+  // Collect unique font keys needed (family::style format)
   const fontKeys = new Set<string>();
   for (const p of items) {
     const style = getFontStyle(p.fontWeight || 400);
     fontKeys.add(`Inter::${style}`);
   }
 
-  // 2. Resolve text styles by name once (not per-item)
+  // Resolve text styles by name once (not per-item)
   const styleNames = new Set<string>();
   for (const p of items) {
     if (p.textStyleName && !p.textStyleId) styleNames.add(p.textStyleName);
@@ -77,15 +81,15 @@ async function createTextBatch(params: any): Promise<{ results: any[] }> {
     textStyles = await figma.getLocalTextStylesAsync();
   }
 
-  // 2a. Resolve paint styles for fontColorStyleName once
+  // Resolve paint styles for fontColorStyleName once
   const hasFontColorStyle = items.some((p: any) => p.fontColorStyleName);
   let paintStyles: any[] | null = null;
   if (hasFontColorStyle) {
     paintStyles = await figma.getLocalPaintStylesAsync();
   }
 
-  // 2b. Resolve text style IDs and collect their fonts for preloading
-  const resolvedTextStyleMap = new Map<string, any>(); // textStyleId → style object
+  // Resolve text style IDs and collect their fonts for preloading
+  const resolvedTextStyleMap = new Map<string, any>();
   for (const p of items) {
     let sid = p.textStyleId;
     if (!sid && p.textStyleName && textStyles) {
@@ -106,7 +110,7 @@ async function createTextBatch(params: any): Promise<{ results: any[] }> {
     }
   }
 
-  // 3. Preload all fonts in parallel (Inter styles + text style fonts)
+  // Preload all fonts in parallel
   await Promise.all(
     [...fontKeys].map(key => {
       const [family, style] = key.split("::");
@@ -114,135 +118,131 @@ async function createTextBatch(params: any): Promise<{ results: any[] }> {
     })
   );
 
-  // 4. Import setCharacters once
   const { setCharacters } = await import("../utils/figma-helpers");
+  return { textStyles, paintStyles, resolvedTextStyleMap, setCharacters };
+}
 
-  // 5. Create nodes (font already loaded, no await per item for fonts)
-  const results = [];
-  for (const p of items) {
-    try {
-      const {
-        x = 0, y = 0, text = "Text", fontSize = 14, fontWeight = 400,
-        fontColor, fontColorVariableId, fontColorStyleName, name = "",
-        parentId, textStyleId, textStyleName,
-        textAlignHorizontal, textAlignVertical,
-        layoutSizingHorizontal, layoutSizingVertical, textAutoResize,
-      } = p;
+/**
+ * Create a single text node. Returns { id, warning? }.
+ * batchHandler handles depth enrichment, warning hoisting, and error wrapping.
+ */
+async function createTextSingle(p: any, ctx: CreateTextContext): Promise<any> {
+  const {
+    x = 0, y = 0, text = "Text", fontSize = 14, fontWeight = 400,
+    fontColor, fontColorVariableId, fontColorStyleName, name = "",
+    parentId, textStyleId, textStyleName,
+    textAlignHorizontal, textAlignVertical,
+    layoutSizingHorizontal, layoutSizingVertical, textAutoResize,
+  } = p;
 
-      const textNode = figma.createText();
-      textNode.x = x;
-      textNode.y = y;
-      textNode.name = name || text;
+  const textNode = figma.createText();
+  textNode.x = x;
+  textNode.y = y;
+  textNode.name = name || text;
 
-      const style = getFontStyle(fontWeight);
-      textNode.fontName = { family: "Inter", style };
-      textNode.fontSize = parseInt(String(fontSize));
+  const style = getFontStyle(fontWeight);
+  textNode.fontName = { family: "Inter", style };
+  textNode.fontSize = parseInt(String(fontSize));
 
-      await setCharacters(textNode, text);
+  await ctx.setCharacters(textNode, text);
 
-      // Text alignment
-      if (textAlignHorizontal) textNode.textAlignHorizontal = textAlignHorizontal;
-      if (textAlignVertical) textNode.textAlignVertical = textAlignVertical;
+  if (textAlignHorizontal) textNode.textAlignHorizontal = textAlignHorizontal;
+  if (textAlignVertical) textNode.textAlignVertical = textAlignVertical;
 
-      // Font color: variableId > styleName > direct color > default black
-      const hints: string[] = [];
-      let colorTokenized = false;
-      if (fontColorVariableId) {
-        const v = await findVariableById(fontColorVariableId);
-        if (v) {
-          const fc = fontColor || { r: 0, g: 0, b: 0, a: 1 };
-          textNode.fills = [{ type: "SOLID", color: { r: fc.r ?? 0, g: fc.g ?? 0, b: fc.b ?? 0 }, opacity: fc.a ?? 1 }];
-          const bound = figma.variables.setBoundVariableForPaint(textNode.fills[0] as SolidPaint, "color", v);
-          textNode.fills = [bound];
-          colorTokenized = true;
-        } else {
-          hints.push(`fontColorVariableId '${fontColorVariableId}' not found.`);
-        }
-      } else if (fontColorStyleName && paintStyles) {
-        const exact = paintStyles.find((s: any) => s.name === fontColorStyleName);
-        const match = exact || paintStyles.find((s: any) => s.name.toLowerCase().includes(fontColorStyleName.toLowerCase()));
-        if (match) {
-          try {
-            await (textNode as any).setFillStyleIdAsync(match.id);
-            colorTokenized = true;
-          } catch (e: any) {
-            hints.push(`fontColorStyleName '${fontColorStyleName}' matched '${match.name}' but failed to apply: ${e.message}`);
-          }
-        } else {
-          hints.push(styleNotFoundHint("fontColorStyleName", fontColorStyleName, paintStyles!.map((s: any) => s.name)));
-        }
+  // Font color: variableId > styleName > direct color > default black
+  const hints: string[] = [];
+  let colorTokenized = false;
+  if (fontColorVariableId) {
+    const v = await findVariableById(fontColorVariableId);
+    if (v) {
+      const fc = fontColor || { r: 0, g: 0, b: 0, a: 1 };
+      textNode.fills = [{ type: "SOLID", color: { r: fc.r ?? 0, g: fc.g ?? 0, b: fc.b ?? 0 }, opacity: fc.a ?? 1 }];
+      const bound = figma.variables.setBoundVariableForPaint(textNode.fills[0] as SolidPaint, "color", v);
+      textNode.fills = [bound];
+      colorTokenized = true;
+    } else {
+      hints.push(`fontColorVariableId '${fontColorVariableId}' not found.`);
+    }
+  } else if (fontColorStyleName && ctx.paintStyles) {
+    const exact = ctx.paintStyles.find((s: any) => s.name === fontColorStyleName);
+    const match = exact || ctx.paintStyles.find((s: any) => s.name.toLowerCase().includes(fontColorStyleName.toLowerCase()));
+    if (match) {
+      try {
+        await (textNode as any).setFillStyleIdAsync(match.id);
+        colorTokenized = true;
+      } catch (e: any) {
+        hints.push(`fontColorStyleName '${fontColorStyleName}' matched '${match.name}' but failed to apply: ${e.message}`);
       }
-      if (!colorTokenized) {
-        const fc = fontColor || { r: 0, g: 0, b: 0, a: 1 };
-        textNode.fills = [{ type: "SOLID", color: { r: fc.r ?? 0, g: fc.g ?? 0, b: fc.b ?? 0 }, opacity: fc.a ?? 1 }];
-        if (fontColor) {
-          const suggestion = await suggestStyleForColor(fontColor, "fontColorStyleName");
-          if (suggestion) hints.push(suggestion);
-        }
-      }
-
-      // Text style: by name > by ID (fonts already preloaded in step 2b/3)
-      let resolvedStyleId = textStyleId;
-      if (!resolvedStyleId && textStyleName && textStyles) {
-        const exact = textStyles.find((s: any) => s.name === textStyleName);
-        if (exact) resolvedStyleId = exact.id;
-        else {
-          const fuzzy = textStyles.find((s: any) => s.name.toLowerCase().includes(textStyleName.toLowerCase()));
-          if (fuzzy) resolvedStyleId = fuzzy.id;
-        }
-      }
-      if (resolvedStyleId) {
-        const cached = resolvedTextStyleMap.get(resolvedStyleId);
-        if (cached) {
-          try {
-            await (textNode as any).setTextStyleIdAsync(cached.id);
-          } catch (e: any) {
-            hints.push(`textStyleName '${textStyleName || resolvedStyleId}' matched but failed to apply: ${e.message}`);
-          }
-        } else {
-          // Name resolved to an ID but getStyleByIdAsync couldn't load it
-          hints.push(`textStyleName '${textStyleName || resolvedStyleId}' matched style ID '${resolvedStyleId}' but the style could not be loaded. It may be from a remote library or deleted.`);
-        }
-      } else if (textStyleName) {
-        hints.push(styleNotFoundHint("textStyleName", textStyleName, textStyles!.map((s: any) => s.name)));
-      } else {
-        // No text style used — suggest matching or creating one
-        hints.push(await suggestTextStyle(fontSize, fontWeight));
-      }
-
-      await appendToParent(textNode, parentId);
-
-      // WCAG recommendations
-      if (fontSize < 12) {
-        hints.push("WCAG: Min 12px text recommended.");
-      }
-
-      if (textAutoResize) {
-        textNode.textAutoResize = textAutoResize;
-      } else if (layoutSizingHorizontal === "FILL" || layoutSizingHorizontal === "FIXED") {
-        textNode.textAutoResize = "HEIGHT";
-      }
-
-      if (layoutSizingHorizontal) {
-        try { textNode.layoutSizingHorizontal = layoutSizingHorizontal; } catch {}
-      }
-      if (layoutSizingVertical) {
-        try { textNode.layoutSizingVertical = layoutSizingVertical; } catch {}
-      }
-
-      let result: any = { id: textNode.id };
-      if (depth !== undefined) {
-        const { nodeSnapshot } = await import("./helpers");
-        const snapshot = await nodeSnapshot(textNode.id, depth);
-        if (snapshot) result = { ...result, ...snapshot };
-      }
-      if (hints.length > 0) result.warning = hints.join(" ");
-      results.push(result);
-    } catch (e: any) {
-      results.push({ error: e.message });
+    } else {
+      hints.push(styleNotFoundHint("fontColorStyleName", fontColorStyleName, ctx.paintStyles!.map((s: any) => s.name)));
     }
   }
-  return { results };
+  if (!colorTokenized) {
+    const fc = fontColor || { r: 0, g: 0, b: 0, a: 1 };
+    textNode.fills = [{ type: "SOLID", color: { r: fc.r ?? 0, g: fc.g ?? 0, b: fc.b ?? 0 }, opacity: fc.a ?? 1 }];
+    if (fontColor) {
+      const suggestion = await suggestStyleForColor(fontColor, "fontColorStyleName");
+      if (suggestion) hints.push(suggestion);
+    }
+  }
+
+  // Text style: by name > by ID (fonts already preloaded)
+  let resolvedStyleId = textStyleId;
+  if (!resolvedStyleId && textStyleName && ctx.textStyles) {
+    const exact = ctx.textStyles.find((s: any) => s.name === textStyleName);
+    if (exact) resolvedStyleId = exact.id;
+    else {
+      const fuzzy = ctx.textStyles.find((s: any) => s.name.toLowerCase().includes(textStyleName.toLowerCase()));
+      if (fuzzy) resolvedStyleId = fuzzy.id;
+    }
+  }
+  if (resolvedStyleId) {
+    const cached = ctx.resolvedTextStyleMap.get(resolvedStyleId);
+    if (cached) {
+      try {
+        await (textNode as any).setTextStyleIdAsync(cached.id);
+      } catch (e: any) {
+        hints.push(`textStyleName '${textStyleName || resolvedStyleId}' matched but failed to apply: ${e.message}`);
+      }
+    } else {
+      hints.push(`textStyleName '${textStyleName || resolvedStyleId}' matched style ID '${resolvedStyleId}' but the style could not be loaded. It may be from a remote library or deleted.`);
+    }
+  } else if (textStyleName) {
+    hints.push(styleNotFoundHint("textStyleName", textStyleName, ctx.textStyles!.map((s: any) => s.name)));
+  } else {
+    hints.push(await suggestTextStyle(fontSize, fontWeight));
+  }
+
+  await appendToParent(textNode, parentId);
+
+  if (fontSize < 12) {
+    hints.push("WCAG: Min 12px text recommended.");
+  }
+
+  if (textAutoResize) {
+    textNode.textAutoResize = textAutoResize;
+  } else if (layoutSizingHorizontal === "FILL" || layoutSizingHorizontal === "FIXED") {
+    textNode.textAutoResize = "HEIGHT";
+  }
+
+  if (layoutSizingHorizontal) {
+    try { textNode.layoutSizingHorizontal = layoutSizingHorizontal; } catch {}
+  }
+  if (layoutSizingVertical) {
+    try { textNode.layoutSizingVertical = layoutSizingVertical; } catch {}
+  }
+
+  const result: any = { id: textNode.id };
+  if (hints.length > 0) result.warning = hints.join(" ");
+  return result;
+}
+
+/**
+ * Batch create_text: preload fonts/styles, then delegate to batchHandler.
+ */
+async function createTextBatch(params: any) {
+  const ctx = await prepCreateText(params);
+  return batchHandler(params, (item) => createTextSingle(item, ctx));
 }
 
 export const figmaHandlers: Record<string, (params: any) => Promise<any>> = {

--- a/src/tools/variables.ts
+++ b/src/tools/variables.ts
@@ -3,7 +3,7 @@ import { flexJson, flexBool } from "../utils/coercion";
 import * as S from "./schemas";
 import type { McpServer, SendCommandFn } from "./types";
 import { mcpJson, mcpError } from "./types";
-import { findVariableById } from "./helpers";
+import { batchHandler, findVariableById } from "./helpers";
 import { formatContrastFailures } from "../utils/wcag";
 
 // ─── Schemas ─────────────────────────────────────────────────────
@@ -363,18 +363,6 @@ async function getNodeVariablesFigma(params: any) {
   return result;
 }
 
-async function batchHandler(params: any, fn: (item: any) => Promise<any>) {
-  const items = params.items || [params];
-  const results = [];
-  for (const item of items) {
-    try {
-      const r = await fn(item);
-      results.push(r && typeof r === "object" && Object.keys(r).length === 0 ? "ok" : r);
-    }
-    catch (e: any) { results.push({ error: e.message }); }
-  }
-  return { results };
-}
 
 export const figmaHandlers: Record<string, (params: any) => Promise<any>> = {
   create_variable_collection: (p) => batchHandler(p, createCollectionSingle),


### PR DESCRIPTION
## Summary
- **variables.ts**: Delete local `batchHandler` duplicate (12 lines), import shared one from `helpers.ts` — gains depth enrichment and warning hoisting for free
- **create-text.ts**: Extract batch-level font/style preloading into `prepCreateText()` and per-item logic into `createTextSingle()`, delegate to `batchHandler` — warnings now hoisted to batch level instead of per-item
- **text.ts**: Refactor `setTextContentBatch` and `setTextPropertiesBatch` with same prep+batchHandler pattern — eliminates manual index-tracking error maps and inconsistent `{ status: "ok" }` wrapper

All batch tools now return consistent `{ results: [...], warnings?: [...] }` format via the shared `batchHandler`.

Closes UFI-19

## Test plan
- [x] `npm run build` — clean
- [x] `create_text` batch (2 items) — returns `{ results, warnings }` with hoisted warnings
- [x] `set_text_content` batch (2 items) — returns `{ results: ["ok", "ok"] }`
- [x] `set_text_properties` batch (2 items) — returns `{ results, warnings }` with hoisted style suggestions
- [x] Variable tools still work (no behavioral change, just using shared implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)