### PR TITLE
feat: component property support

### DIFF
--- a/src/utils/serialize-node.ts
+++ b/src/utils/serialize-node.ts
@@ -92,6 +92,14 @@ export async function serializeNode(
     } catch {
       // mainComponent unavailable (e.g. remote library not loaded)
     }
+    const cp = (inst as any).componentProperties;
+    if (cp && typeof cp === "object" && Object.keys(cp).length > 0) out.componentProperties = cp;
+  }
+
+  // ── Component property references ──────────────────────────────
+  if ("componentPropertyReferences" in node) {
+    const refs = (node as any).componentPropertyReferences;
+    if (refs && typeof refs === "object" && Object.keys(refs).length > 0) out.componentPropertyReferences = refs;
   }
 
   // ── Text style ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **`set_instance_properties`** tool — sets TEXT, BOOLEAN, and INSTANCE_SWAP property values on instances via `setProperties()`
- **`no-text-property`** lint rule — flags text nodes inside components that aren't bound to a component property via `componentPropertyReferences`
- **Serializer** — exposes `componentProperties` on instances and `componentPropertyReferences` on bound nodes

## Test plan
- [x] Lint correctly flags unbound text in components (Card: 2 nodes, TextField: 5 nodes)
- [x] Lint skips bound text, loose text, and instance text
- [x] `set_instance_properties` updates text via property key
- [x] `set_instance_properties` rejects non-instances, bad keys, wrong types
- [x] Batch operations work
- [x] Serializer shows `componentProperties` on instances and `componentPropertyReferences` on bound text nodes
- [x] Clean build, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)