### PR TITLE
feat: fontFamily, component text warnings, delete collections, stronger descriptions

### DIFF
--- a/src/tools/create-frame.ts
+++ b/src/tools/create-frame.ts
@@ -58,7 +58,7 @@ const autoLayoutItem = z.object({
 export function registerMcpTools(server: McpServer, sendCommand: SendCommandFn) {
   server.tool(
     "create_frame",
-    "Create frames in Figma. Supports batch. Prefer fillStyleName or fillVariableId over hardcoded fillColor for design token consistency.",
+    "Create frames in Figma. Batch supported. Use fillStyleName/fillVariableId and strokeStyleName/strokeVariableId instead of hardcoded colors — hardcoded values skip design tokens and will trigger lint warnings.",
     { items: flexJson(z.array(frameItem)).describe("Array of frames to create"), depth: S.depth },
     async (params: any) => {
       try { return mcpJson(await sendCommand("create_frame", params)); }

--- a/src/tools/fill-stroke.ts
+++ b/src/tools/fill-stroke.ts
@@ -37,7 +37,7 @@ const opacityItem = z.object({
 export function registerMcpTools(server: McpServer, sendCommand: SendCommandFn) {
   server.tool(
     "set_fill_color",
-    "Set fill color on nodes. Use styleName to apply a paint style by name, or provide color directly. Batch: pass multiple items.",
+    "Set fill color on nodes. Prefer styleName (design token) over hardcoded color — hardcoded values trigger lint warnings. Batch: pass multiple items.",
     { items: flexJson(z.array(fillItem)).describe("Array of {nodeId, color?, styleName?}"), depth: S.depth },
     async (params: any) => {
       try { return mcpJson(await sendCommand("set_fill_color", params)); }
@@ -47,7 +47,7 @@ export function registerMcpTools(server: McpServer, sendCommand: SendCommandFn) 
 
   server.tool(
     "set_stroke_color",
-    "Set stroke color on nodes. Use styleName to apply a paint style by name. Batch: pass multiple items.",
+    "Set stroke color on nodes. Prefer styleName (design token) over hardcoded color — hardcoded values trigger lint warnings. Batch: pass multiple items.",
     { items: flexJson(z.array(strokeItem)).describe("Array of {nodeId, color?, strokeWeight?, styleName?}"), depth: S.depth },
     async (params: any) => {
       try { return mcpJson(await sendCommand("set_stroke_color", params)); }

--- a/src/tools/variables.ts
+++ b/src/tools/variables.ts
@@ -190,6 +190,16 @@ export function registerMcpTools(server: McpServer, sendCommand: SendCommandFn) 
       catch (e) { return mcpError("Error getting node variables", e); }
     }
   );
+
+  server.tool(
+    "delete_variable_collection",
+    "Delete a variable collection and all its variables. This is destructive and cannot be undone.",
+    { collectionId: z.string().describe("Collection ID to delete") },
+    async ({ collectionId }: any) => {
+      try { return mcpJson(await sendCommand("delete_variable_collection", { collectionId })); }
+      catch (e) { return mcpError("Error deleting variable collection", e); }
+    }
+  );
 }
 
 // ─── Figma Handlers ──────────────────────────────────────────────
@@ -347,6 +357,13 @@ async function getNodeVariablesFigma(params: any) {
 }
 
 
+async function deleteCollectionFigma(params: any) {
+  const c = await findCollectionById(params.collectionId);
+  if (!c) throw new Error(`Collection not found: ${params.collectionId}`);
+  c.remove();
+  return "ok";
+}
+
 export const figmaHandlers: Record<string, (params: any) => Promise<any>> = {
   create_variable_collection: (p) => batchHandler(p, createCollectionSingle),
   create_variable: (p) => batchHandler(p, createVariableSingle),
@@ -361,4 +378,5 @@ export const figmaHandlers: Record<string, (params: any) => Promise<any>> = {
   remove_mode: (p) => batchHandler(p, removeModeSingle),
   set_explicit_variable_mode: (p) => batchHandler(p, setExplicitModeSingle),
   get_node_variables: getNodeVariablesFigma,
+  delete_variable_collection: deleteCollectionFigma,
 };


### PR DESCRIPTION
## Summary
Addresses 4 open issues in one PR:

- **#21 — fontFamily/fontStyle on create_text**: No longer hardcoded to Inter. Agents can pass `fontFamily` and `fontStyle` directly. Fonts are preloaded in the batch prep phase.
- **#20 — Component text property warnings**: `create_component` and `create_component_from_node` now warn when the resulting component has text nodes, prompting agents to use `add_component_property`.
- **#19 — delete_variable_collection**: New tool to remove variable collections. Follows the same pattern as `remove_style`.
- **#17 — Stronger tool descriptions**: Updated descriptions on `create_frame`, `create_text`, `set_fill_color`, `set_stroke_color`, and `create_component` to explicitly push agents toward design tokens and warn that hardcoded values trigger lint warnings.

## Test plan
- [x] `npm run build` passes
- [x] `create_text` with `fontFamily: "Georgia"` creates text with correct font
- [x] `create_component_from_node` on a text node returns warning about unbound text
- [x] `create_variable_collection` + `delete_variable_collection` round-trip works
- [x] Tool descriptions updated and visible in MCP schema

Closes #17, closes #19, closes #20, closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)