### PR TITLE
Secure tunnel bind address + fix local Figma plugin build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,13 @@
 node_modules/
+.DS_Store
 .cursor/
 .env
 dist/
+packages/*/dist/
 .idea/
 certs/
 plugin/
+packages/adapter-figma/src/plugin/code.js
 docs/public/tools-manifest.json
 docs/src/content/docs/tools/
 docs/dist/

--- a/DRAGME.md
+++ b/DRAGME.md
@@ -26,11 +26,17 @@ npm run build
 
 This bridges the MCP server and the Figma plugin via channels. Everything runs locally on your machine — no data leaves localhost.
 
+**Security note:** By default the Vibma tunnel binds to `127.0.0.1` so it is only accessible from your local machine. To expose it to your LAN you may set:
+
+```bash
+VIBMA_HOST=0.0.0.0 npm run socket
+```
+
 ```bash
 npm run socket
 ```
 
-You should see: `WebSocket server running on port 3055`
+You should see: `Vibma tunnel running on http://127.0.0.1:3055`
 
 ### About ports
 
@@ -123,7 +129,7 @@ Each channel enforces **exactly one Figma plugin and one MCP server**. If a seco
 Use the relay's built-in debug endpoint to see who's connected:
 
 ```bash
-curl http://localhost:3055/channels
+curl http://127.0.0.1:3055/channels
 ```
 
 Returns:
@@ -142,7 +148,7 @@ If using Claude Code, the `channel_info` MCP tool returns the same data without 
 
 **Plugin won't connect to WebSocket**: Make sure the relay is running. The plugin connects to `ws://localhost:3055` by default.
 
-**"Connection rejected" in plugin UI**: Another plugin is already connected to that channel. Disconnect it first or use a different channel name. Run `curl http://localhost:3055/channels` to see what's connected.
+**"Connection rejected" in plugin UI**: Another plugin is already connected to that channel. Disconnect it first or use a different channel name. Run `curl http://127.0.0.1:3055/channels` to see what's connected.
 
 **MCP shows disconnected**: Restart your AI tool after changing MCP config. Stdio-based MCP servers can't hot-reload.
 
@@ -199,7 +205,7 @@ If the plugin shows **Disconnected** on port 3055, try the following before aski
 2. Restart the relay: `npm run socket`
 3. Ask the user to close and reopen the Figma plugin.
 
-If `join_channel` fails with a `ROLE_OCCUPIED` error, another MCP server is already connected to that channel. Use `channel_info` (or `curl http://localhost:3055/channels`) to inspect who's connected. The user needs to disconnect the other MCP client or use a different channel name.
+If `join_channel` fails with a `ROLE_OCCUPIED` error, another MCP server is already connected to that channel. Use `channel_info` (or `curl http://127.0.0.1:3055/channels`) to inspect who's connected. The user needs to disconnect the other MCP client or use a different channel name.
 
 If the issue persists after these steps, direct the user to the [Vibma Discord](https://discord.gg/4XTedZdwV6) for help.
 

--- a/packages/adapter-figma/tsup.config.ts
+++ b/packages/adapter-figma/tsup.config.ts
@@ -16,5 +16,8 @@ export default defineConfig({
   async onSuccess() {
     copyFileSync('src/plugin/manifest.json', '../../plugin/manifest.json');
     copyFileSync('src/plugin/ui.html', '../../plugin/ui.html');
+    // If the user imported the *source* manifest at packages/adapter-figma/src/plugin/manifest.json,
+    // Figma will try to load packages/adapter-figma/src/plugin/code.js. Ensure it exists after build.
+    copyFileSync('../../plugin/code.js', 'src/plugin/code.js');
   },
 });

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'tsup';
+import { cpSync } from 'fs';
 
 export default defineConfig({
   entry: [
@@ -14,10 +15,15 @@ export default defineConfig({
   format: ['cjs', 'esm'],
   dts: true,
   clean: true,
-  outDir: '../../dist',
+  outDir: 'dist',
   target: 'node18',
   sourcemap: true,
   minify: false,
   splitting: false,
   bundle: true,
+  async onSuccess() {
+    // Keep the root-level `dist/` folder for the repo scripts/docs,
+    // but also emit `packages/core/dist/` so workspace imports resolve.
+    cpSync('dist', '../../dist', { recursive: true, force: true });
+  },
 });

--- a/packages/tunnel/src/index.ts
+++ b/packages/tunnel/src/index.ts
@@ -374,8 +374,10 @@ wss.on("connection", (ws: WebSocket) => {
   });
 });
 
-// uncomment this to allow connections in windows wsl
-// httpServer.listen(port, "0.0.0.0", () => {
-httpServer.listen(port, () => {
-  console.log(`WebSocket server running on port ${port}`);
+// Security note: bind to localhost by default so the tunnel isn't exposed to LAN.
+// Set VIBMA_HOST=0.0.0.0 to explicitly opt into LAN exposure (e.g. for WSL scenarios).
+const host = process.env.VIBMA_HOST || "127.0.0.1";
+
+httpServer.listen(port, host, () => {
+  console.log(`Vibma tunnel running on http://${host}:${port}`);
 });


### PR DESCRIPTION
Summary
- Bind tunnel to 127.0.0.1 by default (opt-in LAN exposure via VIBMA_HOST=0.0.0.0).
- Update DRAGME.md with a security note and updated examples/log output.
- Fix Figma dev plugin load error when importing packages/adapter-figma/src/plugin/manifest.json by ensuring packages/adapter-figma/src/plugin/code.js exists after build.
- Align workspace build output: emit packages/core/dist/ for @ufira/vibma/* exports while keeping root dist/ for existing scripts/docs.

## Testing

1. npm run build
2. npm run socket  (expect: Vibma tunnel running on http://127.0.0.1:3055)
3. Optional LAN: VIBMA_HOST=0.0.0.0 npm run socket
4. In Figma, reload/run the dev plugin and click Connect again