### PR TITLE
Add Vibma agent template for Figma MCP workflows

### DIFF
--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -1,0 +1,44 @@
+# Agent Instructions (Figma via Vibma MCP)
+
+Use **Vibma** as the *only* integration for interacting with Figma (read/search/export/create/edit/delete). Do not attempt to “guess” Figma geometry or reimplement Figma APIs. If a task involves a Figma URL, node id, screenshots, tokens/variables, or design-to-code, route it through **Vibma MCP tools**.
+
+## Required workflow
+
+1. **Ensure the local WebSocket relay is running**
+   - From the Vibma repo root: `npm run socket`
+   - Default port: `3055` (alternatives: `3056–3058` via `VIBMA_PORT`)
+   - Security: relay binds to `127.0.0.1` by default. To expose to LAN explicitly: `VIBMA_HOST=0.0.0.0 npm run socket`
+
+2. **Ensure the Figma plugin is running and connected**
+   - In Figma: Plugins → Development → run “Vibma”
+   - In the plugin UI: select the matching port and channel, then click **Connect**
+   - If the plugin reloads/disconnects after a build, the user must click **Connect** again.
+
+3. **Connect from MCP to the same channel**
+   - Call `join_channel` with the channel name (default: `vibma`)
+   - Call `ping` and confirm a `pong` with a document name/page
+
+Only proceed with Figma actions after `ping` succeeds.
+
+## MCP server configuration
+
+Prefer running the Vibma MCP server from the built artifact:
+
+- `node /absolute/path/to/vibma/dist/mcp.js --edit`
+
+If developing Vibma itself, source mode is acceptable:
+
+- `npx tsx /absolute/path/to/vibma/src/mcp.ts --edit`
+
+Access tiers:
+- Omit flags for read-only
+- Use `--create` for create-only
+- Use `--edit` for full edit/delete
+
+## Operational rules
+
+- **Disconnects are normal** after rebuilding Vibma/plugin outputs; re-run `join_channel` + `ping`.
+- Prefer Vibma inspection tools for ground truth (node properties, variables/tokens, rendered screenshots).
+- When asked to “match Figma”, always fetch design context/screenshot via Vibma first, then implement.
+- If a request would require Figma UI interaction the agent cannot perform, ask the user to (a) open the plugin, (b) click **Connect**, or (c) provide the relevant node id/URL, then retry via Vibma.
+


### PR DESCRIPTION
## Title

Add Vibma agent template for Figma MCP workflows

## Summary

This PR adds an agent template for Vibma-based Figma work:

- adds `templates/AGENTS.md`
- documents the required relay → plugin → MCP connection flow
- makes Vibma the required path for Figma inspection and editing tasks
- captures reconnect expectations after plugin rebuilds/reloads

## Why

Agent-driven tooling needs repo-specific operational guidance to behave correctly.

Without this template, an agent is likely to:
- guess Figma structure instead of using Vibma tools
- skip the relay/plugin connection checks
- fail after plugin reloads because reconnect behavior is undocumented
- use inconsistent MCP startup modes and permissions

This template gives contributors a stable, reusable instruction set for Codex/Claude-style agents and reduces avoidable setup and workflow mistakes.

## Suggestion

I suggest adding this template to the main project as an official contributor aid.

Reasons:
- it encodes Vibma-specific constraints that generic agents will not infer
- it improves consistency across AI-assisted contributions
- it lowers review/debug overhead caused by incorrect Figma interaction patterns
- it makes the expected `join_channel` + `ping` verification step explicit
