### PR TITLE
feat: add VIBMA_SERVER env var and fix local address protocol detection

### DIFF
--- a/CARRYME.md
+++ b/CARRYME.md
@@ -96,6 +96,26 @@ If using a non-default port, add `--port=`:
 }
 ```
 
+### Remote or non-localhost relay
+
+By default the MCP server connects to `localhost`. If the relay is running on a different host (e.g. Docker, a VM, or a remote machine), set `VIBMA_SERVER`:
+
+```json
+{
+  "mcpServers": {
+    "Vibma": {
+      "command": "npx",
+      "args": ["-y", "@ufira/vibma", "--edit"],
+      "env": { "VIBMA_SERVER": "host.docker.internal" }
+    }
+  }
+}
+```
+
+The `--server=<host>` CLI arg also works and takes priority over the env var.
+
+Local addresses (`localhost`, `127.0.0.1`, `host.docker.internal`, `0.0.0.0`, `*.local`) use `ws://` and `http://`. All other addresses use `wss://` and `https://`.
+
 ## 5. Connect
 
 1. In the Figma plugin, set the channel name to `vibma` (or any name you like)

--- a/DRAGME.md
+++ b/DRAGME.md
@@ -113,6 +113,26 @@ If using a non-default port, add `--port=`:
 }
 ```
 
+### Remote or non-localhost relay
+
+By default the MCP server connects to `localhost`. If the relay is running on a different host (e.g. Docker, a VM, or a remote machine), set `VIBMA_SERVER`:
+
+```json
+{
+  "mcpServers": {
+    "Vibma": {
+      "command": "node",
+      "args": ["/absolute/path/to/vibma/dist/mcp.js", "--edit"],
+      "env": { "VIBMA_SERVER": "host.docker.internal" }
+    }
+  }
+}
+```
+
+The `--server=<host>` CLI arg also works and takes priority over the env var.
+
+Local addresses (`localhost`, `127.0.0.1`, `host.docker.internal`, `0.0.0.0`, `*.local`) use `ws://` and `http://`. All other addresses use `wss://` and `https://`.
+
 ## 5. Connect
 
 1. In the Figma plugin, set the channel name to `vibma` (or any name you like)

--- a/packages/core/src/mcp.ts
+++ b/packages/core/src/mcp.ts
@@ -85,9 +85,11 @@ let versionWarning: string | null = null;
 const args = process.argv.slice(2);
 const serverArg = args.find((a) => a.startsWith("--server="));
 const portArg = args.find((a) => a.startsWith("--port="));
-const serverUrl = serverArg ? serverArg.split("=")[1] : "localhost";
+const serverUrl = serverArg ? serverArg.split("=")[1] : (process.env.VIBMA_SERVER || "localhost");
 if (portArg) activePort = parseInt(portArg.split("=")[1]);
-const WS_URL = serverUrl === "localhost" ? `ws://${serverUrl}` : `wss://${serverUrl}`;
+const isLocal = /^(localhost|127\.0\.0\.1|host\.docker\.internal|0\.0\.0\.0)(:|$)/.test(serverUrl)
+  || serverUrl.endsWith(".local");
+const WS_URL = isLocal ? `ws://${serverUrl}` : `wss://${serverUrl}`;
 
 // Access-tier flags: read is always on, --create / --edit opt-in
 const caps = {
@@ -104,7 +106,7 @@ function connectToFigma(port: number = activePort) {
     return;
   }
 
-  const wsUrl = serverUrl === "localhost" ? `${WS_URL}:${port}` : WS_URL;
+  const wsUrl = isLocal ? `${WS_URL}:${port}` : WS_URL;
   logger.info(`Connecting to Figma socket server at ${wsUrl}...`);
   ws = new WebSocket(wsUrl);
 
@@ -327,8 +329,8 @@ server.registerTool(
       }
 
       if (method === "list") {
-        const url = serverUrl === "localhost"
-          ? `http://localhost:${activePort}/channels`
+        const url = isLocal
+          ? `http://${serverUrl}:${activePort}/channels`
           : `https://${serverUrl}/channels`;
         const response = await fetch(url);
         if (!response.ok) return { content: [{ type: "text", text: `Relay returned ${response.status}: ${await response.text()}` }] };
@@ -338,8 +340,8 @@ server.registerTool(
 
       if (method === "delete") {
         const targetChannel = params.channel || currentChannel || "vibma";
-        const url = serverUrl === "localhost"
-          ? `http://localhost:${activePort}/channels/${encodeURIComponent(targetChannel)}`
+        const url = isLocal
+          ? `http://${serverUrl}:${activePort}/channels/${encodeURIComponent(targetChannel)}`
           : `https://${serverUrl}/channels/${encodeURIComponent(targetChannel)}`;
         const res = await fetch(url, { method: "DELETE" });
         const body = await res.json() as { ok: boolean; message: string };


### PR DESCRIPTION
## Summary

- Add `VIBMA_SERVER` env var so users can configure the relay hostname without CLI args
- Fix protocol detection: recognize common local addresses beyond just `"localhost"` (`127.0.0.1`, `host.docker.internal`, `0.0.0.0`, `*.local`)
- Fix hardcoded `localhost` in HTTP URLs for `connection(method: "list")` and `connection(method: "delete")`

## Problem

The MCP server assumes any server that isn't literally `"localhost"` is a remote production server and forces `wss://` + `https://`. This breaks common local setups:

- **Docker containers** — the relay runs on the host, reachable via `host.docker.internal`, but the MCP tries `wss://host.docker.internal:3055` which fails because the relay speaks `ws://`
- **VMs / WSL** — same issue when accessing the host relay via IP
- **LAN setups** — running the relay on `0.0.0.0` and connecting from another machine on the network

Additionally, there was no way to set the relay hostname via environment variable (only the `--server=` CLI arg), making it harder to configure in Docker entrypoints and CI environments.

## Changes

**`packages/core/src/mcp.ts`**
- `VIBMA_SERVER` env var support with correct precedence: `--server=` CLI arg > `VIBMA_SERVER` env var > `"localhost"`
- Replace `serverUrl === "localhost"` with regex-based `isLocal` check: `/^(localhost|127\.0\.0\.1|host\.docker\.internal|0\.0\.0\.0)(:|$)/` plus `*.local` suffix
- Fix HTTP URLs in `connection.list` and `connection.delete` to use `serverUrl` instead of hardcoded `localhost`

**`CARRYME.md` / `DRAGME.md`**
- New "Remote or non-localhost relay" section documenting `VIBMA_SERVER` and protocol behavior

## Backward compatibility

Fully backward compatible. Without `VIBMA_SERVER` or `--server=`, behavior is identical to before (`localhost` matches `isLocal`, uses `ws://`/`http://`).

## Test plan

- [ ] Default behavior unchanged: MCP connects to `ws://localhost:3055` with no args/env
- [ ] `VIBMA_SERVER=host.docker.internal` connects via `ws://host.docker.internal:3055`
- [ ] `--server=` CLI arg takes priority over `VIBMA_SERVER` env var
- [ ] `--server=example.com` still uses `wss://` (non-local)
- [ ] `connection(method: "list")` and `connection(method: "delete")` use correct protocol and hostname