### PR TITLE
fix: remove hardcoded localhost in Figma plugin UI

### DIFF
--- a/packages/adapter-figma/src/plugin/ui.html
+++ b/packages/adapter-figma/src/plugin/ui.html
@@ -177,7 +177,7 @@
       /* Form */
       .form-row {
         display: grid;
-        grid-template-columns: 76px 1fr;
+        grid-template-columns: 1fr 76px 1fr;
         gap: 8px;
         align-items: end;
       }
@@ -392,9 +392,13 @@
         <div id="connection-info" class="banner-secondary"></div>
       </div>
 
-      <!-- Port + Channel -->
+      <!-- Host + Port + Channel -->
       <div class="form-row">
         <div class="form-group">
+          <label id="label-host"></label>
+          <input type="text" id="host" value="localhost" placeholder="localhost" />
+        </div>
+        <div class="form-group" style="max-width: 76px;">
           <label id="label-port"></label>
           <select id="port">
             <option value="3055" selected>3055</option>
@@ -454,6 +458,7 @@
           tagline: "Vibe Design meets Figma — AI-powered MCP bridge",
           btnConnect: "Connect",
           btnDisconnect: "Disconnect",
+          labelHost: "Host",
           labelPort: "Port",
           labelChannel: "Channel",
           statusDisconnected: "Not connected to Vibma relay",
@@ -498,6 +503,7 @@
 
       function applyLocale() {
         connectButton.textContent = state.connected ? t("btnDisconnect") : t("btnConnect");
+        document.getElementById("label-host").textContent = t("labelHost");
         document.getElementById("label-port").textContent = t("labelPort");
         document.getElementById("label-channel").textContent = t("labelChannel");
         document.getElementById("warning-box").innerHTML =
@@ -531,6 +537,7 @@
       document.getElementById("version-badge").textContent = `v${VIBMA_VERSION}`;
 
       // UI Elements
+      const hostInput = document.getElementById("host");
       const portInput = document.getElementById("port");
       const channelInput = document.getElementById("channel-name");
       const connectButton = document.getElementById("btn-connect");
@@ -545,6 +552,12 @@
       const progressMessage = document.getElementById("progress-message");
       const progressStatus = document.getElementById("progress-status");
       const progressPercentage = document.getElementById("progress-percentage");
+
+      // Match isLocal logic from MCP server (packages/core/src/mcp.ts)
+      function isLocalHost(host) {
+        return /^(localhost|127\.0\.0\.1|host\.docker\.internal|0\.0\.0\.0)(:|$)/.test(host)
+          || host.endsWith(".local");
+      }
 
       function buildBannerInfo(isConnected) {
         if (!isConnected) {
@@ -619,6 +632,7 @@
 
         connectButton.textContent = isConnected ? t("btnDisconnect") : t("btnConnect");
         connectButton.className = isConnected ? "secondary" : "";
+        hostInput.disabled = isConnected;
         portInput.disabled = isConnected;
         channelInput.disabled = isConnected;
       }
@@ -632,7 +646,9 @@
           }
 
           state.serverPort = port;
-          const wsUrl = `ws://localhost:${port}`;
+          const host = hostInput.value.trim() || "localhost";
+          const wsProto = isLocalHost(host) ? "ws" : "wss";
+          const wsUrl = isLocalHost(host) ? `${wsProto}://${host}:${port}` : `${wsProto}://${host}`;
 
           state.socket = new WebSocket(wsUrl);
 
@@ -881,7 +897,10 @@
         updateConnectionStatus(false, t("statusResetting"));
 
         try {
-          await fetch(`http://localhost:${port}/channels/${encodeURIComponent(channel)}`, { method: "DELETE" });
+          const host = hostInput.value.trim() || "localhost";
+          const httpProto = isLocalHost(host) ? "http" : "https";
+          const baseUrl = isLocalHost(host) ? `${httpProto}://${host}:${port}` : `${httpProto}://${host}`;
+          await fetch(`${baseUrl}/channels/${encodeURIComponent(channel)}`, { method: "DELETE" });
         } catch (e) {
           console.warn("Could not reach relay for reset:", e);
         }


### PR DESCRIPTION
## Summary

- Add **Host** input field to Figma plugin UI (defaults to `localhost`)
- Replace hardcoded `ws://localhost` and `http://localhost` with protocol-aware URL construction
- Apply the same `isLocal` regex from the MCP server (#68) to detect local vs remote relay addresses

Companion fix to #68 — the MCP server side was fixed but the plugin UI still had hardcoded localhost in two places.

## Changes

**`packages/adapter-figma/src/plugin/ui.html`**
- New Host text input alongside Port and Channel (3-column grid layout)
- `isLocalHost()` helper matching the MCP server's regex: `localhost`, `127.0.0.1`, `host.docker.internal`, `0.0.0.0`, `*.local`
- `connectToServer()` — builds WS URL using host input + protocol detection (`ws://` for local, `wss://` for remote; port appended only for local)
- Reset tunnel handler — same fix for the HTTP DELETE channel call
- Host input disabled while connected (matches port/channel behavior)
- i18n label for "Host"

## Test plan

- [ ] **Default behavior unchanged**: plugin connects to `ws://localhost:3055` with default Host value
- [ ] **Custom local host**: set Host to `127.0.0.1`, verify connects via `ws://127.0.0.1:3055`
- [ ] **Docker host**: set Host to `host.docker.internal`, verify connects via `ws://host.docker.internal:3055`
- [ ] **Remote host**: set Host to `relay.example.com`, verify connects via `wss://relay.example.com` (no port appended)
- [ ] **`.local` host**: set Host to `my-mac.local`, verify connects via `ws://my-mac.local:3055`
- [ ] **Reset tunnel**: verify reset uses correct protocol and host for the HTTP DELETE call
- [ ] **Input disabled when connected**: Host, Port, and Channel inputs all disabled after connecting
- [ ] **Layout**: 3-column form row renders correctly, Host input doesn't overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)