### PR TITLE
fix: audit bugs — warnings, dead handler, lint instructions

### DIFF
--- a/packages/adapter-figma/src/handlers/fill-stroke.ts
+++ b/packages/adapter-figma/src/handlers/fill-stroke.ts
@@ -155,7 +155,8 @@ export async function setCornerSingle(p: any) {
   }
 
   const result: any = {};
-  if (hints.length > 0) result.warning = hints.join(" ");
+  const unique = [...new Set(hints)];
+  if (unique.length > 0) result.warning = unique.join(" ");
   return result;
 }
 

--- a/packages/adapter-figma/src/handlers/lint.ts
+++ b/packages/adapter-figma/src/handlers/lint.ts
@@ -124,9 +124,9 @@ const FIX_INSTRUCTIONS: Record<string, string> = {
   "hardcoded-token": 'Bind to a FLOAT variable instead of using hardcoded numbers. For cornerRadius: frames(method:"update", items:[{id, cornerRadius:{radius:"Radii/Medium"}}]). For padding/itemSpacing: items:[{id, layout:{paddingTop:"Spacing/Medium", itemSpacing:"Spacing/Small"}}]. For strokeWeight: items:[{id, stroke:{weight:"Border/Thick"}}]. For opacity: items:[{id, opacity:"Opacity/Subtle"}]. Pass a variable name string instead of a number. If no FLOAT variable exists, create one with variables(method:"create") first.',
   "no-text-style": 'Apply a text style: frames(method:"update", items:[{id, text:{textStyleName:"..."}}]). If no text styles exist, create one with styles(method:"create", type:"text") first.',
   "fixed-in-autolayout": 'Use frames(method:"update", items:[{id, layout:{layoutSizingHorizontal:"FILL"}}]) or "HUG" instead of FIXED. FILL stretches to fill the parent, HUG shrinks to fit content.',
-  "default-name": 'Use frames(method:"update", items:[{id, properties:{name:"descriptive name"}}]) to rename.',
+  "default-name": 'Use frames(method:"update", items:[{id, name:"descriptive name"}]) to rename.',
   "empty-container": 'These frames have no children — likely leftover. Delete with frames(method:"delete", items:[{id}]) or add content.',
-  "stale-text-name": 'These text node names don\'t match their content. Use frames(method:"update", items:[{id, properties:{name:"..."}}]) to sync, or leave if the name is intentional.',
+  "stale-text-name": 'These text node names don\'t match their content. Use frames(method:"update", items:[{id, name:"..."}]) to sync, or leave if the name is intentional.',
   "no-text-property": 'Use components(method:"update", items:[{id, propertyName:"TextLabel", action:"add", type:"TEXT", defaultValue:"..."}]) to expose the text as an editable property on the component.',
   // -- WCAG fix instructions --
   "wcag-contrast": 'Adjust text color or background to meet AA contrast (4.5:1 normal text, 3:1 large text). Use frames(method:"update") with fill or text.fontColor to change colors.',

--- a/packages/adapter-figma/src/handlers/patch-nodes.ts
+++ b/packages/adapter-figma/src/handlers/patch-nodes.ts
@@ -80,12 +80,14 @@ async function patchSingleNode(item: any, textCtx: TextPropsContext | null): Pro
 
   // 5. Corner radius
   if (item.cornerRadius) {
-    await setCornerSingle({ nodeId: item.nodeId, ...item.cornerRadius });
+    const r = await setCornerSingle({ nodeId: item.nodeId, ...item.cornerRadius });
+    if (r.warning) result.warning = appendWarning(result.warning, r.warning);
   }
 
   // 6. Opacity
   if (item.opacity !== undefined) {
-    await setOpacitySingle({ nodeId: item.nodeId, opacity: item.opacity });
+    const r = await setOpacitySingle({ nodeId: item.nodeId, opacity: item.opacity });
+    if (r.warning) result.warning = appendWarning(result.warning, r.warning);
   }
 
   // 7. Effects

--- a/packages/adapter-figma/src/handlers/registry.ts
+++ b/packages/adapter-figma/src/handlers/registry.ts
@@ -138,6 +138,7 @@ export const allFigmaHandlers: Record<string, (params: any) => Promise<any>> = {
   "components.get": componentsHandlers.components,
   "components.create": componentsHandlers.components,
   "components.update": componentsHandlers.components,
+  "components.delete": componentsHandlers.components,
 
   // ─── instances endpoint ───
   "instances.get": componentsHandlers.instances,


### PR DESCRIPTION
## Summary
- **Surface cornerRadius/opacity warnings** in `patch-nodes` update — previously silently discarded (inconsistent with layout/stroke paths which did warn)
- **Deduplicate cornerRadius warnings** — single variable name expanding to 4 corners was producing 4 identical "Variable not found" warnings
- **Register `components.delete` handler** — YAML schema and help docs exposed it but handler was never wired in `registry.ts`, returning `Unknown command`
- **Fix lint fix instructions** — `default-name` and `stale-text-name` rules referenced `properties:{name:"..."}` instead of correct `name:"..."` on PatchItem

## Test plan
- [x] `frames.update` with `cornerRadius: {radius: "nonexistent/var"}` now warns (was silent)
- [x] `frames.update` with `opacity: "nonexistent/var"` now warns (was silent)
- [x] cornerRadius warning appears once, not 4x
- [x] `components.delete` works (was `Unknown command`)
- [x] `lint.check` `default-name` fix text uses `name:` not `properties:{name:}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)