### PR TITLE
feat: add hug-cross-axis lint rule and runtime warnings

### DIFF
--- a/packages/adapter-figma/src/handlers/create-frame.ts
+++ b/packages/adapter-figma/src/handlers/create-frame.ts
@@ -107,6 +107,18 @@ export async function setupFrameNode(
     hints.push({ type: "warn", message: "HUG on both axes — content grows unboundedly and text won't wrap. Use FILL or FIXED width with HUG height for responsive layout." });
   }
 
+  // HUG on cross-axis of constrained parent — child won't fill available space
+  if (parent && "layoutMode" in parent && (parent as any).layoutMode !== "NONE") {
+    const parentAL = parent as any;
+    const isHorizontal = parentAL.layoutMode === "HORIZONTAL";
+    const parentCross = isHorizontal ? parentAL.layoutSizingVertical : parentAL.layoutSizingHorizontal;
+    const childCross = isHorizontal ? node.layoutSizingVertical : node.layoutSizingHorizontal;
+    if ((parentCross === "FIXED" || parentCross === "FILL") && childCross === "HUG") {
+      const crossProp = isHorizontal ? "layoutSizingVertical" : "layoutSizingHorizontal";
+      hints.push({ type: "warn", message: `HUG on cross-axis of constrained parent — won't fill available space. Use ${crossProp}:"FILL".` });
+    }
+  }
+
   // WCAG 2.5.8: target size recommendation for interactive elements
   if (looksInteractive(node) && (node.width < 24 || node.height < 24)) {
     hints.push({ type: "suggest", message: "WCAG: Min 24x24px for touch targets." });

--- a/packages/adapter-figma/src/handlers/create-text.ts
+++ b/packages/adapter-figma/src/handlers/create-text.ts
@@ -271,6 +271,18 @@ async function createTextSingle(p: any, ctx: CreateTextContext) {
     }
   }
 
+  // HUG on cross-axis of constrained parent — text won't fill available space
+  if (textNode.parent && "layoutMode" in textNode.parent && (textNode.parent as any).layoutMode !== "NONE") {
+    const parentAL = textNode.parent as any;
+    const isHorizontal = parentAL.layoutMode === "HORIZONTAL";
+    const parentCross = isHorizontal ? parentAL.layoutSizingVertical : parentAL.layoutSizingHorizontal;
+    const childCross = isHorizontal ? textNode.layoutSizingVertical : textNode.layoutSizingHorizontal;
+    if ((parentCross === "FIXED" || parentCross === "FILL") && childCross === "HUG") {
+      const crossProp = isHorizontal ? "layoutSizingVertical" : "layoutSizingHorizontal";
+      hints.push({ type: "warn", message: `Text has HUG on cross-axis of constrained parent — won't fill available space and text won't wrap. Use ${crossProp}:"FILL".` });
+    }
+  }
+
   const result: any = { id: textNode.id };
   if (hints.length > 0) result.hints = hints;
   return result;

--- a/packages/adapter-figma/src/handlers/lint.ts
+++ b/packages/adapter-figma/src/handlers/lint.ts
@@ -129,6 +129,7 @@ const FIX_INSTRUCTIONS: Record<string, string> = {
   "stale-text-name": 'These text node names don\'t match their content. Use frames(method:"update", items:[{id, name:"..."}]) to sync, or leave if the name is intentional.',
   "no-text-property": 'Use components(method:"update", items:[{id, propertyName:"TextLabel", action:"add", type:"TEXT", defaultValue:"..."}]) to expose the text as an editable property on the component.',
   "overlapping-children": 'Children are stacked at the same position — likely missing x/y. Either: (1) convert to auto-layout with frames(method:"update", items:[{id, layout:{layoutMode:"VERTICAL"}}]) so children flow automatically, or (2) reposition each child with frames(method:"update", items:[{id:"<childId>", x:<value>, y:<value>}]).',
+  "hug-cross-axis": 'Child has HUG on the cross-axis of a constrained parent — it won\'t fill the available space. Text won\'t wrap and elements look undersized. Fix: set the cross-axis sizing to FILL. For a vertical container: frames(method:"update", items:[{id, layoutSizingHorizontal:"FILL"}]). For a horizontal container: frames(method:"update", items:[{id, layoutSizingVertical:"FILL"}]).',
   "unbounded-hug": 'HUG on both axes breaks responsive behavior — content grows unboundedly, text won\'t wrap, and nested hug chains create unpredictable sizing cascades. For frames: FILL or FIXED width + HUG height (mirrors CSS block-level elements). For text nodes: use FILL width + HUG height so text wraps within its parent, or set textAutoResize:"HEIGHT" for fixed-width wrapping. Fix frames: frames(method:"update", items:[{id, layout:{layoutSizingHorizontal:"FILL"}}]). Fix text: text(method:"update", items:[{id, layoutSizingHorizontal:"FILL", layoutSizingVertical:"HUG"}]) or items:[{id, textAutoResize:"HEIGHT"}].',
   // -- WCAG fix instructions --
   "wcag-contrast": 'Adjust text color or background to meet AA contrast (4.5:1 normal text, 3:1 large text). Use frames(method:"update") with fill or text.fontColor to change colors.',
@@ -219,6 +220,30 @@ async function walkNode(node: BaseNode, depth: number, issues: Issue[], ctx: Lin
       if (th === "HUG" && tv === "HUG") {
         issues.push({ rule: "unbounded-hug", nodeId: node.id, nodeName: node.name, extra: { nodeType: "TEXT" } });
         if (issues.length >= ctx.maxFindings) return;
+      }
+    }
+  }
+
+  // -- Rule: hug-cross-axis --
+  // Child has HUG on the cross-axis of a constrained parent — won't fill available space
+  if (ctx.runAll || ctx.ruleSet.has("hug-cross-axis")) {
+    if (node.parent && "layoutMode" in node.parent && "layoutSizingHorizontal" in node) {
+      const parent = node.parent as any;
+      if (parent.layoutMode !== "NONE") {
+        const isHorizontal = parent.layoutMode === "HORIZONTAL";
+        // Cross-axis: vertical layout → check horizontal sizing; horizontal layout → check vertical sizing
+        const parentCross = isHorizontal ? parent.layoutSizingVertical : parent.layoutSizingHorizontal;
+        const childCross = isHorizontal ? (node as any).layoutSizingVertical : (node as any).layoutSizingHorizontal;
+        if ((parentCross === "FIXED" || parentCross === "FILL") && childCross === "HUG") {
+          const crossAxis = isHorizontal ? "vertical" : "horizontal";
+          issues.push({
+            rule: "hug-cross-axis",
+            nodeId: node.id,
+            nodeName: node.name,
+            extra: { crossAxis, parentSizing: parentCross, parentId: parent.id, parentName: parent.name },
+          });
+          if (issues.length >= ctx.maxFindings) return;
+        }
       }
     }
   }

--- a/packages/adapter-figma/src/handlers/text.ts
+++ b/packages/adapter-figma/src/handlers/text.ts
@@ -165,6 +165,18 @@ export async function setTextPropertiesSingle(p: any, ctx: TextPropsContext) {
       warnings.push({ type: "warn", message: "Text with HUG on both axes won't wrap. Use layoutSizingHorizontal:\"FILL\" + layoutSizingVertical:\"HUG\" so text fills parent width and wraps, or set textAutoResize:\"HEIGHT\" for fixed-width wrapping." });
     }
   }
+  // HUG on cross-axis of constrained parent — text won't fill available space
+  if ((p.layoutSizingHorizontal || p.layoutSizingVertical) &&
+      node.parent && "layoutMode" in node.parent && (node.parent as any).layoutMode !== "NONE") {
+    const parentAL = node.parent as any;
+    const isHorizontal = parentAL.layoutMode === "HORIZONTAL";
+    const parentCross = isHorizontal ? parentAL.layoutSizingVertical : parentAL.layoutSizingHorizontal;
+    const childCross = isHorizontal ? node.layoutSizingVertical : node.layoutSizingHorizontal;
+    if ((parentCross === "FIXED" || parentCross === "FILL") && childCross === "HUG") {
+      const crossProp = isHorizontal ? "layoutSizingVertical" : "layoutSizingHorizontal";
+      warnings.push({ type: "warn", message: `Text has HUG on cross-axis of constrained parent — won't fill available space. Use ${crossProp}:"FILL".` });
+    }
+  }
   if (p.textStyleName && p.textStyleId) {
     warnings.push({ type: "warn", message: "Both textStyleName and textStyleId provided — used textStyleId. Pass only one." });
   }

--- a/schema/tools/lint.yaml
+++ b/schema/tools/lint.yaml
@@ -21,6 +21,7 @@ notes: |
   //     "stale-text-name" — text node name doesn't match its content
   //     "no-text-property" — component text not exposed as editable property
   //     "overlapping-children" — multiple children at the same position in a non-auto-layout frame (agent likely forgot x/y)
+  //     "hug-cross-axis" — child has HUG on the cross-axis of a constrained parent (won't fill available space; use FILL)
   //     "unbounded-hug" — frame or text node with HUG on both axes (breaks responsiveness, text won't wrap; use FILL/FIXED width + HUG height)
   //   Accessibility (WCAG) rules:
   //     "wcag-contrast" — text contrast ratio below 4.5:1 (WCAG AA)


### PR DESCRIPTION
## Summary
- New lint rule `hug-cross-axis`: flags children with HUG on the cross-axis of a constrained (FIXED/FILL) auto-layout parent — e.g. nav items in a vertical container that don't fill width, so text won't wrap
- Runtime warnings on create-frame, create-text, and text update paths with actionable fix (which property to set to FILL)

## Test plan
- [ ] Create a vertical auto-layout frame (FILL width), add a child frame with HUG width → confirm runtime warning suggests `layoutSizingHorizontal:"FILL"`
- [ ] Same with a text node → confirm warning
- [ ] Run `lint(method:"check", rules:["hug-cross-axis"])` on a page with the above → confirm findings with correct axis/parent info
- [ ] Verify no false positives: child with FILL cross-axis in constrained parent → no warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)