### PR TITLE
refactor: extract normalizeAliases as shared normalization contract

### DIFF
--- a/packages/adapter-figma/src/handlers/components.ts
+++ b/packages/adapter-figma/src/handlers/components.ts
@@ -1,4 +1,4 @@
-import { batchHandler, appendAndApplySizing, checkOverlappingSiblings, applyTokens, resolveComponentPropertyKey, applyFillWithAutoBind, applySizing, type Hint } from "./helpers";
+import { batchHandler, appendAndApplySizing, checkOverlappingSiblings, applyTokens, resolveComponentPropertyKey, applyFillWithAutoBind, applySizing, normalizeAliases, TEXT_ALIAS_KEYS, FRAME_ALIAS_KEYS, type Hint } from "./helpers";
 import { setupFrameNode } from "./create-frame";
 import { createDispatcher, paginate, pickFields } from "@ufira/vibma/endpoint";
 import {
@@ -63,6 +63,9 @@ async function createInlineChildren(
 ): Promise<void> {
   for (const child of children) {
     if (child.type === "text") {
+      // Normalize color aliases to canonical fills form
+      normalizeAliases(child, TEXT_ALIAS_KEYS);
+
       const family = child.fontFamily || "Inter";
       const style = child.fontStyle || "Regular";
       const font = await resolveFontAsync(family, style);
@@ -76,18 +79,10 @@ async function createInlineChildren(
       await setCharacters(textNode, text);
       textNode.name = child.name || child.componentPropertyName || text;
 
-      // Color: normalize aliases the same way batchHandler does
-      let fills = child.fills;
-      if (!fills && child.fontColorVariableName) {
-        fills = { _variable: child.fontColorVariableName };
-      } else if (!fills && child.fontColorStyleName) {
-        fills = { _style: child.fontColorStyleName };
-      } else if (!fills && child.fontColor) {
-        fills = child.fontColor;
-      }
+      // Color: fills is now canonical (normalized above)
       const colorHints: Hint[] = [];
-      const colorSet = await applyFillWithAutoBind(textNode, { fills }, colorHints);
-      if (!colorSet && fills === undefined) {
+      const colorSet = await applyFillWithAutoBind(textNode, { fills: child.fills }, colorHints);
+      if (!colorSet && child.fills === undefined) {
         textNode.fills = [{ type: "SOLID", color: { r: 0, g: 0, b: 0 }, opacity: 1 }];
       }
       hints.push(...colorHints);
@@ -105,9 +100,19 @@ async function createInlineChildren(
 
       // Sizing: default FILL + HUG inside auto-layout parent
       const parentIsAL = appendTo.layoutMode && appendTo.layoutMode !== "NONE";
+      const effectiveH = child.layoutSizingHorizontal || (parentIsAL ? "FILL" : undefined);
+      const effectiveV = child.layoutSizingVertical || (parentIsAL ? "HUG" : undefined);
+
+      // textAutoResize must be set before FILL sizing to avoid Figma errors
+      if (child.textAutoResize) {
+        textNode.textAutoResize = child.textAutoResize;
+      } else if (effectiveH === "FILL" || effectiveH === "FIXED") {
+        textNode.textAutoResize = "HEIGHT";
+      }
+
       applySizing(textNode, appendTo, {
-        layoutSizingHorizontal: child.layoutSizingHorizontal || (parentIsAL ? "FILL" : undefined),
-        layoutSizingVertical: child.layoutSizingVertical || (parentIsAL ? "HUG" : undefined),
+        layoutSizingHorizontal: effectiveH,
+        layoutSizingVertical: effectiveV,
       }, hints);
 
       // Auto-create TEXT property and bind
@@ -122,6 +127,9 @@ async function createInlineChildren(
         }
       }
     } else if (child.type === "frame") {
+      // Normalize fill/stroke aliases to canonical form before setupFrameNode
+      normalizeAliases(child, FRAME_ALIAS_KEYS);
+
       const frame = figma.createFrame();
       frame.name = child.name || "Frame";
       frame.fills = [];

--- a/packages/adapter-figma/src/handlers/create-frame.ts
+++ b/packages/adapter-figma/src/handlers/create-frame.ts
@@ -1,4 +1,4 @@
-import { batchHandler, appendAndApplySizing, applySizing, checkOverlappingSiblings, applyFillWithAutoBind, applyStrokeWithAutoBind, applyCornerRadius, applyTokens, type Hint } from "./helpers";
+import { batchHandler, appendAndApplySizing, applySizing, checkOverlappingSiblings, applyFillWithAutoBind, applyStrokeWithAutoBind, applyCornerRadius, applyTokens, normalizeAliases, FRAME_ALIAS_KEYS, type Hint } from "./helpers";
 import { looksInteractive } from "@ufira/vibma/utils/wcag";
 import { framesCreateFrame, framesCreateAutoLayout } from "@ufira/vibma/guards";
 
@@ -6,6 +6,10 @@ import { framesCreateFrame, framesCreateAutoLayout } from "@ufira/vibma/guards";
  * Shared setup for frame-like nodes (Frame, Component).
  * Applies layout, fill, stroke, corner radius, opacity, min/max, WCAG checks.
  * Returns { parent, hints } so the caller can add type-specific logic.
+ *
+ * CONTRACT: `p` must have been through `normalizeAliases()` — `fills` and `strokes`
+ * must be in canonical form (not `fillColor`, `fontColor`, etc.).
+ * When called via batchHandler this is automatic; other callers must normalize first.
  */
 export async function setupFrameNode(
   node: FrameNode | ComponentNode,
@@ -187,6 +191,9 @@ async function createSingleAutoLayout(p: any) {
     if ("appendChild" in originalParent) (originalParent as any).appendChild(frame);
     for (const node of nodes) frame.appendChild(node);
 
+    // Normalize fill/stroke aliases — this path bypasses batchHandler's per-item normalization
+    normalizeAliases(p, FRAME_ALIAS_KEYS);
+
     // Apply all frame properties (layout, fill, stroke, etc.)
     const hints: Hint[] = [];
     await applyTokens(frame, { opacity: p.opacity }, hints);
@@ -213,6 +220,7 @@ async function createSingleAutoLayout(p: any) {
 
     await applyFillWithAutoBind(frame, p, hints);
     await applyStrokeWithAutoBind(frame, p, hints);
+    await applyCornerRadius(frame, p, hints);
 
     const result: any = { id: frame.id };
     if (hints.length > 0) result.hints = hints;

--- a/packages/adapter-figma/src/handlers/helpers.ts
+++ b/packages/adapter-figma/src/handlers/helpers.ts
@@ -60,6 +60,67 @@ function sendBatchProgress(commandId: string, processed: number, total: number, 
   });
 }
 
+/** Minimal key set for normalizeAliases: text context (fills + fontColor aliases). */
+export const TEXT_ALIAS_KEYS: ReadonlySet<string> = new Set(["fills", "fontColor"]);
+/** Minimal key set for normalizeAliases: frame context (fills + strokes aliases). */
+export const FRAME_ALIAS_KEYS: ReadonlySet<string> = new Set(["fills", "strokes"]);
+
+/**
+ * Normalize user-facing param aliases to canonical forms. Mutates `p` in place.
+ * Idempotent — once `fills`/`strokes` is set, alias fields are deleted.
+ *
+ * - fontColor / fontColorVariableName / fontColorStyleName → fills (when keys has "fontColor")
+ * - fillColor / fillVariableName / fillStyleName / color / backgroundColor → fills (when keys has "fills")
+ * - strokeColor / strokeVariableName / strokeStyleName → strokes (when keys has "strokes")
+ *
+ * @param p    The item params object (mutated in place)
+ * @param keys Key set controlling which alias paths activate. Pass null to normalize all.
+ */
+export function normalizeAliases(p: Record<string, any>, keys: ReadonlySet<string> | null): void {
+  const hasFills = !keys || keys.has("fills");
+  const hasFontColor = !keys || keys.has("fontColor");
+  const hasStrokes = !keys || keys.has("strokes");
+
+  if (hasFills && !p.fills) {
+    const colorAlias = p.color !== undefined && !hasFontColor ? "color"
+      : p.backgroundColor !== undefined ? "backgroundColor"
+      : p.background !== undefined ? "background"
+      : null;
+    if (colorAlias) { p.fillColor = p[colorAlias]; delete p[colorAlias]; }
+    if (hasFontColor) {
+      if (p.fontColorVariableId !== undefined) {
+        p.fills = { _variableId: p.fontColorVariableId }; delete p.fontColorVariableId;
+      } else if (p.fontColorVariableName !== undefined) {
+        p.fills = { _variable: p.fontColorVariableName }; delete p.fontColorVariableName;
+      } else if (p.fontColorStyleName !== undefined) {
+        p.fills = { _style: p.fontColorStyleName }; delete p.fontColorStyleName;
+      } else if (p.fontColor !== undefined) {
+        const c = coerceColor(p.fontColor);
+        p.fills = c ? [solidPaint(c)] : p.fontColor; delete p.fontColor;
+      }
+    }
+    if (!p.fills && p.fillVariableName !== undefined) {
+      p.fills = { _variable: p.fillVariableName }; delete p.fillVariableName;
+    } else if (!p.fills && p.fillStyleName !== undefined) {
+      p.fills = { _style: p.fillStyleName }; delete p.fillStyleName;
+    } else if (!p.fills && p.fillColor !== undefined) {
+      const c = coerceColor(p.fillColor);
+      p.fills = c ? [solidPaint(c)] : p.fillColor; delete p.fillColor;
+    }
+  }
+
+  if (hasStrokes && !p.strokes) {
+    if (p.strokeVariableName !== undefined) {
+      p.strokes = { _variable: p.strokeVariableName }; delete p.strokeVariableName;
+    } else if (p.strokeStyleName !== undefined) {
+      p.strokes = { _style: p.strokeStyleName }; delete p.strokeStyleName;
+    } else if (p.strokeColor !== undefined) {
+      const c = coerceColor(p.strokeColor);
+      p.strokes = c ? [solidPaint(c)] : p.strokeColor; delete p.strokeColor;
+    }
+  }
+}
+
 export async function batchHandler<TItem, TResult>(
   params: { items?: TItem[]; depth?: number } & Record<string, unknown>,
   fn: (item: TItem) => Promise<TResult>,
@@ -77,61 +138,8 @@ export async function batchHandler<TItem, TResult>(
   for (let i = 0; i < items.length; i++) {
     try {
       if (guard) {
-        // Normalize aliases before guard check
-        const p = items[i] as any;
-        // Normalize all fill aliases → fills (canonical form, highest priority last)
-        if (guard.keys.has("fills") && !p.fills) {
-          // color/backgroundColor/background → fillColor first
-          const colorAlias = p.color !== undefined && !guard.keys.has("fontColor") ? "color"
-            : p.backgroundColor !== undefined ? "backgroundColor"
-            : p.background !== undefined ? "background"
-            : null;
-          if (colorAlias) { p.fillColor = p[colorAlias]; delete p[colorAlias]; }
-          // Text context: fontColor* → fills (when guard has both fills and fontColor)
-          if (guard.keys.has("fontColor")) {
-            if (p.fontColorVariableId !== undefined) {
-              p.fills = { _variableId: p.fontColorVariableId };
-              delete p.fontColorVariableId;
-            } else if (p.fontColorVariableName !== undefined) {
-              p.fills = { _variable: p.fontColorVariableName };
-              delete p.fontColorVariableName;
-            } else if (p.fontColorStyleName !== undefined) {
-              p.fills = { _style: p.fontColorStyleName };
-              delete p.fontColorStyleName;
-            } else if (p.fontColor !== undefined) {
-              const c = coerceColor(p.fontColor);
-              p.fills = c ? [solidPaint(c)] : p.fontColor;
-              delete p.fontColor;
-            }
-          }
-          // Resolve in priority order: fillVariableName > fillStyleName > fillColor
-          if (!p.fills && p.fillVariableName !== undefined) {
-            p.fills = { _variable: p.fillVariableName };
-            delete p.fillVariableName;
-          } else if (!p.fills && p.fillStyleName !== undefined) {
-            p.fills = { _style: p.fillStyleName };
-            delete p.fillStyleName;
-          } else if (!p.fills && p.fillColor !== undefined) {
-            const c = coerceColor(p.fillColor);
-            p.fills = c ? [solidPaint(c)] : p.fillColor;
-            delete p.fillColor;
-          }
-        }
-        // Normalize all stroke aliases → strokes (same pattern as fills)
-        if (guard.keys.has("strokes") && !p.strokes) {
-          if (p.strokeVariableName !== undefined) {
-            p.strokes = { _variable: p.strokeVariableName };
-            delete p.strokeVariableName;
-          } else if (p.strokeStyleName !== undefined) {
-            p.strokes = { _style: p.strokeStyleName };
-            delete p.strokeStyleName;
-          } else if (p.strokeColor !== undefined) {
-            const c = coerceColor(p.strokeColor);
-            p.strokes = c ? [solidPaint(c)] : p.strokeColor;
-            delete p.strokeColor;
-          }
-        }
-        rejectUnknownParams(p, guard.keys, guard.help);
+        normalizeAliases(items[i] as any, guard.keys);
+        rejectUnknownParams(items[i] as any, guard.keys, guard.help);
       }
       let result: any = await fn(items[i]);
       if (depth !== undefined && result?.id) {


### PR DESCRIPTION
## Summary

- Extract alias normalization from `batchHandler` into a standalone `normalizeAliases()` function
- Any code path that creates nodes can now call it — no more manual reimplementation
- Closes normalization gaps in inline children and wrap-existing auto_layout

## Problem

`batchHandler` converts user-facing params (`fontColorVariableName`, `fillColor`, `strokeColor`) into canonical internal forms (`fills._variable`, `fills`, `strokes`). This conversion was embedded inside `batchHandler` and only ran when a guard was provided.

Code paths bypassing `batchHandler` had to reimplement this:
- `createInlineChildren` — manual normalization block that was buggy (fontColorVariableName didn't work on first implementation)
- `createSingleAutoLayout` wrap path — called `applyFillWithAutoBind` with raw aliases, also missing `applyCornerRadius` entirely

## Changes

- **`helpers.ts`**: Extract `normalizeAliases(p, keys)` — idempotent, mutates in place, key-set-driven. Export `TEXT_ALIAS_KEYS` and `FRAME_ALIAS_KEYS` constants. `batchHandler` now calls `normalizeAliases()` instead of inline logic — zero behavioral change.
- **`components.ts`**: `createInlineChildren` calls `normalizeAliases(child, TEXT_ALIAS_KEYS)` for text and `normalizeAliases(child, FRAME_ALIAS_KEYS)` for frames. Removes manual normalization block. Adds `textAutoResize: "HEIGHT"` default for FILL-width text (matching `createTextSingle`).
- **`create-frame.ts`**: Wrap-existing auto_layout path calls `normalizeAliases(p, FRAME_ALIAS_KEYS)` before fill/stroke application. Adds missing `applyCornerRadius`. CONTRACT JSDoc on `setupFrameNode`.

## Test plan

- [x] batchHandler: text.create with fontColorVariableName → bound
- [x] batchHandler: frames.create with fillColor hex → applied
- [x] batchHandler: frames.create with fillVariableName + strokeVariableName → bound
- [x] Inline text child with fontColorVariableName → bound
- [x] Inline text child with fontColor hex → applied
- [x] Inline text child with no color → default black
- [x] Inline frame child with fillVariableName + strokeColor → fill bound, stroke applied
- [x] Wrap auto_layout with fillColor + cornerRadius → both applied (cornerRadius was missing before)
- [x] components.audit on inline children → clean
- [x] frames.update with fillVariableName → bound (patch path unaffected)
- [x] npm run build → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)