### PR TITLE
fix: correct variable alias syntax in duplicate color warning

### DIFF
--- a/packages/adapter-figma/src/handlers/variables.ts
+++ b/packages/adapter-figma/src/handlers/variables.ts
@@ -328,7 +328,7 @@ async function createVariableSingle(p: any, collection: any) {
             type: "warn",
             message: `"${variable.name}" has the same ${mode.name} value (${newHex}) as existing variable "${sib.name}". ` +
               `If they should stay in sync, bind as alias: variables(method:"update", collectionId:"${collection.name}", ` +
-              `items:[{name:"${variable.name}", valuesByMode:{"${mode.name}":"{${sib.name}}"}}])`,
+              `items:[{name:"${variable.name}", valuesByMode:{"${mode.name}":{type:"VARIABLE_ALIAS", name:"${sib.name}"}}}])`,
           });
           break;
         }


### PR DESCRIPTION
## Summary
- Fix the quick-fix suggestion in duplicate color warnings to use the correct `{type:"VARIABLE_ALIAS", name:"varName"}` format instead of the broken `{varName}` shorthand

## Test plan
- [x] Create variable with duplicate color → warning appears with fix command
- [x] Copy-paste the suggested fix command → alias binds successfully
- [x] Verify variable now shows `VARIABLE_ALIAS` reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)